### PR TITLE
Get lftp with Nix rather than apt-get

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Should probably do this with Nix
-      - name: Install lftp
-        run: sudo apt-get install lftp
-
       - name: Install Nix
         uses: cachix/install-nix-action@v12
 
@@ -52,4 +48,4 @@ jobs:
           #   Value: The text of the ssh private key
           WWW_HASKELL_ORG_SSH_KEY: ${{ secrets.WWW_HASKELL_ORG_SSH_KEY }}
         run: |
-          sh ./deploy.sh
+          nix run --quiet -f . lftp -c sh ./deploy.sh

--- a/default.nix
+++ b/default.nix
@@ -77,4 +77,4 @@ let
   };
 in
   if pkgs.lib.inNixShell then builder
-  else { inherit builder built; inherit (pkgs) linkchecker; }
+  else { inherit builder built; inherit (pkgs) linkchecker lftp; }


### PR DESCRIPTION
Here's one way to use Nix to get `lftp` instead of installing it with `apt-get`.

Down the line we will probably want to refactor how we do this, but it seems fine for now. I haven't tested it on GitHub CI, but this variant did work as expected locally.